### PR TITLE
增加GNU证书说明和控件优化

### DIFF
--- a/embelish.cpp
+++ b/embelish.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "embelish.h"
 
 embelish::embelish(QWidget *parent) : QWidget(parent)
@@ -621,6 +638,8 @@ void oneClickEmbelish(const char *filename)
     psBilateralFilterCV(src, dst);
 
     psLuminanceContrastCV(dst, dst);
+
+    psSaturationCV(dst, dst);
 
     psSharpenCV(dst, dst);
 

--- a/embelish.h
+++ b/embelish.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef EMBELISH_H
 #define EMBELISH_H
 

--- a/func_bar.cpp
+++ b/func_bar.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "func_bar.h"
 
 FuncBar::FuncBar(QWidget *parent)

--- a/func_bar.h
+++ b/func_bar.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef FUNC_BAR_H
 #define FUNC_BAR_H
 

--- a/kylin-scanner.pro.user
+++ b/kylin-scanner.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.11.1, 2020-06-15T02:07:28. -->
+<!-- Written by QtCreator 4.11.1, 2020-06-16T20:05:09. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -69,7 +69,7 @@
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/test/kylin-scanner/build-kylin-scanner-Desktop_Qt_5_14_2_GCC_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/yusq/build-kylin-scanner-Desktop_Qt_5_14_2_GCC_64bit-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -297,7 +297,7 @@
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
     <value type="QString" key="RunConfiguration.WorkingDirectory"></value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/test/kylin-scanner/build-kylin-scanner-Desktop_Qt_5_14_2_GCC_64bit-Debug</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/yusq/build-kylin-scanner-Desktop_Qt_5_14_2_GCC_64bit-Debug</value>
    </valuemap>
    <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>

--- a/kylin-scanner.pro.user
+++ b/kylin-scanner.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.11.1, 2020-06-16T20:05:09. -->
+<!-- Written by QtCreator 4.11.1, 2020-06-17T16:56:30. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/kylin_sane.cpp
+++ b/kylin_sane.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "kylin_sane.h"
 //KylinSane* KylinSane::instance=nullptr; //静态成员需要先初始化
 

--- a/kylin_sane.h
+++ b/kylin_sane.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef KYLIN_SANE_H
 #define KYLIN_SANE_H
 

--- a/kylincombobox.cpp
+++ b/kylincombobox.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "kylincombobox.h"
 
 KylinComboBox::KylinComboBox(QWidget *parent) : QComboBox(parent)

--- a/kylincombobox.cpp
+++ b/kylincombobox.cpp
@@ -79,3 +79,19 @@ void KylinComboBox::showPopup()
 
     QComboBox::showPopup();
 }
+
+void KylinComboBox::colorGray()
+{
+    this->setStyleSheet(
+                "QComboBox{border-radius:4px;background-color:#0D0400;color:gray;}"
+                "QComboBox QLineEdit{border-radios:4px;}"
+                "QComboBox:hover{border-radius:4px;background-color:#0D0400;color:white;}"
+                "QComboBox::drop-down{border-radius:4px;}" //下拉按钮
+                "QComboBox::down-arrow{border-radius:4px;border-image:url(:/icon/icon/down.png);}"//下拉箭头
+                "QComboBox QAbstractItemView{margin-top:4px solid #0D0400;color:white;border-radius:4px;background-color:#888888;}"
+                "QComboBox QAbstractItemView::item{width:180px;height: 32px;border-radius:4px;}"//下拉列表框样式
+                "QComboBox QAbstractItemView::item:hover:selected{background-color:#6F6F6F;}"
+                );
+    this->setEditable(false);
+    this->setFocusPolicy(Qt::NoFocus);
+}

--- a/kylincombobox.h
+++ b/kylincombobox.h
@@ -28,6 +28,8 @@ public:
     explicit KylinComboBox(QWidget *parent = nullptr);
     ~KylinComboBox();
 
+    void colorGray();
+
 protected:
     virtual void mousePressEvent(QMouseEvent *e);  //添加鼠标点击事件
     virtual void hidePopup(); //重载隐藏下拉框

--- a/kylincombobox.h
+++ b/kylincombobox.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef KYLINCOMBOBOX_H
 #define KYLINCOMBOBOX_H
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "widget.h"
 #include <QApplication>
 #include <QLabel>

--- a/mark_dialog.cpp
+++ b/mark_dialog.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "mark_dialog.h"
 #include <QPainter>
 #include <QBitmap>

--- a/mark_dialog.h
+++ b/mark_dialog.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef MARK_DIALOG_H
 #define MARK_DIALOG_H
 #include <QDialog>

--- a/my_label.cpp
+++ b/my_label.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "my_label.h"
 #include <QPainter>
 #include <QPen>

--- a/my_label.h
+++ b/my_label.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef MY_LABEL_H
 #define MY_LABEL_H
 #include <QLabel>

--- a/rectify.cpp
+++ b/rectify.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "rectify.h"
 
 //度数转换

--- a/rectify.h
+++ b/rectify.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef RECTIFY_H
 #define RECTIFY_H
 

--- a/scan_display.cpp
+++ b/scan_display.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "scan_display.h"
 #include "func_bar.h"
 #include <QDebug>

--- a/scan_display.h
+++ b/scan_display.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef SCAN_DISPLAY_H
 #define SCAN_DISPLAY_H
 

--- a/scan_set.cpp
+++ b/scan_set.cpp
@@ -102,6 +102,7 @@ ScanSet::ScanSet(QWidget *parent)
 
     setKylinLable();
     setKylinComboBox();
+    setKylinScanSetNotEnable();
     setKylinHBoxLayout();
 
 
@@ -289,6 +290,35 @@ void ScanSet::setKylinComboBox()
 //    setKylinComboBoxAttributes(textLocation, strListLocation);
 }
 
+void ScanSet::setKylinScanSetNotEnable()
+{
+    KylinSane& instance = KylinSane::getInstance();
+    bool device_status = true;
+
+    device_status = instance.getKylinSaneStatus();
+
+    if(!device_status)
+    {
+        textColor->setEnabled(false);
+        textColor->colorGray();
+
+        textSize->setEnabled(false);
+        textSize->colorGray();
+
+        textResalution->setEnabled(false);
+        textResalution->colorGray();
+
+        textFormat->setEnabled(false);
+        textFormat->colorGray();
+
+        textName->setEnabled(false);
+        textName->setStyleSheet("QLineEdit{background-color:rgb(15,08,01);color:gray;border-radius:6px;}");
+
+        btnLocation->setEnabled(false);
+        btnLocation->setStyleSheet("QPushButton{color:gray;}");
+    }
+}
+
 void ScanSet::setKylinLable()
 {
     KylinSane& instance = KylinSane::getInstance();
@@ -324,22 +354,24 @@ void ScanSet::setKylinLable()
     {
         // No find scan device
         textDevice->setText("无可用设备");
+        textDevice->setStyleSheet("QLabel{background-color:rgb(15,08,01);color:gray;border-radius:6px;}");
     }
     else {
         textDevice->setText(instance.getKylinSaneName());
+        textDevice->setStyleSheet("QLabel{background-color:rgb(15,08,01);color:rgb(232,232,232);border-radius:6px;}");
     }
-    textDevice->setStyleSheet("QLabel{background-color:rgb(15,08,01);color:rgb(232,232,232);border-radius:6px;}");
     textDevice->setFixedSize(180,32);
 
     if(!device_status)
     {
         // No find scan device
-        textType->setText("平板式");
+        textType->setText("");
+        textType->setStyleSheet("QLabel{background-color:rgb(15,08,01);color:gray;border-radius:6px;}");
     }
     else {
         textType->setText(instance.getKylinSaneType());
+        textType->setStyleSheet("QLabel{background-color:rgb(15,08,01);color:rgb(232,232,232);border-radius:6px;}");
     }
-    textType->setStyleSheet("QLabel{background-color:rgb(15,08,01);color:rgb(232,232,232);border-radius:6px;}");
     textType->setFixedSize(180,32);
 
     textName->setText("扫描文件名");

--- a/scan_set.cpp
+++ b/scan_set.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "scan_set.h"
 QString curPath;
 ScanSet::ScanSet(QWidget *parent)

--- a/scan_set.h
+++ b/scan_set.h
@@ -55,6 +55,9 @@ public:
      */
     void setKylinComboBox();
 
+
+    void setKylinScanSetNotEnable();
+
     /**
      * @brief setKylinComboBoxAttributes 设置组合框属性
      * @param combo 需要属性设置的组合框

--- a/scan_set.h
+++ b/scan_set.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef SCAN_SET_H
 #define SCAN_SET_H
 

--- a/send_mail.cpp
+++ b/send_mail.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "send_mail.h"
 #include <QPainter>
 #include <QDebug>

--- a/send_mail.h
+++ b/send_mail.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef SEND_MAIL_H
 #define SEND_MAIL_H
 #include <QDialog>

--- a/sider.yml
+++ b/sider.yml
@@ -1,0 +1,56 @@
+# linter:
+# # https://help.sider.review/getting-started/custom-configuration
+
+#   # https://help.sider.review/tools/others/misspell
+#   misspell:
+#     exclude:
+#       - vendor
+#       - "**/*.min.js"
+#       - exclude_file.rb
+#     targets:
+#       - target_directory
+#       - another_target_directory/foo.rb
+#       - bar.rb
+#     locale: UK
+#     ignore: center,behavior
+
+#   # https://help.sider.review/tools/cplusplus/cppcheck
+#   cppcheck:
+#     target: "src"
+#     ignore: "vendor"
+#     enable: "all"
+#     std: "c99"
+#     project: "your_project.sln"
+#     language: "c++"
+
+#   # https://help.sider.review/tools/shellscript/shellcheck
+#   shellcheck:
+#     target: "src/**/*.{sh,bash}"
+#     include: "SC2104,SC2105"
+#     exclude: "SC1000,SC1118"
+#     enable: "all"
+#     shell: "bash"
+#     severity: "error"
+#     norc: true
+
+#   # https://help.sider.review/tools/cplusplus/cpplint
+#   cpplint:
+#     target: "src"
+#     extensions: "c,cc"
+#     headers: "hpp,hxx"
+#     filter: "-whitespace,+whitespace/braces,-legal/copyright"
+#     linelength: 100
+#     exclude: "test/*.c"
+
+# # https://help.sider.review/getting-started/custom-configuration#ignore
+# ignore:
+#   - "*.pdf"
+#   - "*.mp4"
+#   - "images/**"
+
+# # https://help.sider.review/getting-started/custom-configuration#branchesexclude
+# branches:
+#   exclude:
+#     - master
+#     - development
+#     - /^release-.*$/

--- a/title_bar.cpp
+++ b/title_bar.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include <QLabel>
 #include <QPushButton>
 #include <QHBoxLayout>

--- a/title_bar.h
+++ b/title_bar.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef TITLE_BAR_H
 #define TITLE_BAR_H
 

--- a/widget.cpp
+++ b/widget.cpp
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #include "widget.h"
 #include <QVBoxLayout>
 #include <QIcon>

--- a/widget.h
+++ b/widget.h
@@ -1,3 +1,20 @@
+/*
+* Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, see <http://www.gnu.org/licenses/&gt;.
+*
+*/
 #ifndef WIDGET_H
 #define WIDGET_H
 


### PR DESCRIPTION
1. 当没有搜索到扫描设备时，设置扫描设置控件不可用，并显示成灰色。

2. 为文件增加GNU证书声明。

3. 增加代码审查side.yml文件。