### PR TITLE
clear stack and set button not enabled before scan

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f kylin-scanner.pro.user

--- a/src/func_bar.cpp
+++ b/src/func_bar.cpp
@@ -95,7 +95,7 @@ FuncBar::FuncBar(QWidget *parent)
     line2->setFrameStyle(QFrame::VLine);
     line2->setStyleSheet("QFrame{color:rgb(32,30,29)}");
 
-//    setKylinScanSetNotEnable();
+    setKylinScanSetNotEnable();
 
     vBoxLay1 = new QVBoxLayout();
     vBoxLay2 = new QVBoxLayout();
@@ -250,6 +250,19 @@ void FuncBar::setKylinScanSetEnable()
         btnBeautify->setEnabled(true);
         btnRectify->setEnabled(true);
         btnOrc->setEnabled(true);
+        btnScan->setEnabled(true);
+    }
+}
+
+void FuncBar::setBtnScanEnable()
+{
+    KylinSane& instance = KylinSane::getInstance();
+    bool device_status = true;
+
+    device_status = instance.getKylinSaneStatus();
+
+    if(device_status)
+    {
         btnScan->setEnabled(true);
     }
 }

--- a/src/func_bar.h
+++ b/src/func_bar.h
@@ -53,6 +53,7 @@ public:
     void keyPressEvent(QKeyEvent *e);
     void setKylinScanSetNotEnable();
     void setKylinScanSetEnable();
+    void setBtnScanEnable();
     void setFontSize(QLabel *label, int n);
     int flagBeautify = 0; //一键美化标志
     int flagRectify = 0; //智能纠偏标志

--- a/src/scan_display.cpp
+++ b/src/scan_display.cpp
@@ -479,6 +479,9 @@ void scan_display::scan()
     vStackedLayout->setCurrentIndex(1);
     vStackedLayout->setCurrentIndex(2);
     vStackedLayout->setCurrentIndex(3);
+
+    stack.clear();
+
     img5->load("/tmp/scanner/scan.pnm");
     pixmap_scaled(*img5,labDisplay5);
     vStackedLayout->setCurrentWidget(myWidget1);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -196,6 +196,9 @@ void Widget::save_image(QString fileName)
 void Widget::save_scan_file()
 {
     QImage img;
+
+    pFuncBar->setKylinScanSetEnable();
+
     img.load("/tmp/scanner/scan.pnm");
     QString pathName = pScanSet->getTextLocation() + "/" + pScanSet->getTextName();
     qDebug()<<"pathName:"<<pathName;
@@ -243,7 +246,7 @@ void Widget::scan_result(bool ret)
         device = true;
         pScanSet->setKylinComboBox();
         pScanSet->setKylinLable();
-        pFuncBar->setKylinScanSetEnable();
+        pFuncBar->setBtnScanEnable();
         pScanSet->setKylinScanSetEnable();
      //   thread.terminate();
     }


### PR DESCRIPTION
1. 在扫描未开始时，设置一键美化、智能纠偏和文字识别功能不可用；
2. 在扫描开始前，都清空已有的栈，这是为了避免不断出栈到当前扫描之前的图片。